### PR TITLE
Adds more flexibility to custom level specs for trianing builds

### DIFF
--- a/Assets/Resources/==Managers==/CommonElements.prefab
+++ b/Assets/Resources/==Managers==/CommonElements.prefab
@@ -18765,13 +18765,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   levelTextFiles:
-  - {fileID: 4900000, guid: 4dd78d57817c6444eb09fe4c816f645e, type: 3}
-  - {fileID: 4900000, guid: 639404744e3da4b3997394218ee948a6, type: 3}
-  - {fileID: 4900000, guid: c53013c2df5067a4fa2b265664670313, type: 3}
-  - {fileID: 4900000, guid: 6f489af45804b134f975cafdae2edf22, type: 3}
-  - {fileID: 4900000, guid: 23b21fc4bc54fbb4cb16f617088cca74, type: 3}
-  - {fileID: 4900000, guid: c9e7b73f32ecb6242a72e2395226fa1b, type: 3}
-  - {fileID: 4900000, guid: 46687e28c0733b04381250dfd1691a82, type: 3}
+  - {fileID: 4900000, guid: c50b11e4e560e484e89af03b4f7b761c, type: 3}
   characterConfigs:
   - {fileID: 11400000, guid: c6b44fe2a04fe7b44872f86875a07caf, type: 2}
   - {fileID: 11400000, guid: c716ed11fa455404ab8b58937cdf7629, type: 2}

--- a/Assets/Scenes/LocalGame/LocalGamePlay.unity
+++ b/Assets/Scenes/LocalGame/LocalGamePlay.unity
@@ -1647,7 +1647,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6070971951046079248, guid: 7a56ab4814f3248008a3ec1f6d5a52d2, type: 3}
       propertyPath: levelTextFiles.Array.size
-      value: 7
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6070971951046079248, guid: 7a56ab4814f3248008a3ec1f6d5a52d2, type: 3}
       propertyPath: levelTextFiles.Array.data[1]

--- a/Assets/Scenes/Networked/NetworkGamePlay.unity
+++ b/Assets/Scenes/Networked/NetworkGamePlay.unity
@@ -1534,7 +1534,7 @@ PrefabInstance:
     - target: {fileID: 6070971951046079248, guid: 7a56ab4814f3248008a3ec1f6d5a52d2, type: 3}
       propertyPath: levelTextFiles.Array.data[0]
       value: 
-      objectReference: {fileID: 4900000, guid: 4dd78d57817c6444eb09fe4c816f645e, type: 3}
+      objectReference: {fileID: 4900000, guid: c50b11e4e560e484e89af03b4f7b761c, type: 3}
     - target: {fileID: 6070971951103539348, guid: 7a56ab4814f3248008a3ec1f6d5a52d2, type: 3}
       propertyPath: m_IsActive
       value: 1

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -6,6 +6,7 @@ using GameConstant;
 using System.Linq;
 using Photon.Pun;
 using Random = UnityEngine.Random;
+using System.IO;
 
 public class GameManager : MonoBehaviour
 {
@@ -31,6 +32,8 @@ public class GameManager : MonoBehaviour
     public int CombatResultSyncedCount = 0;
 
     private float lastTurnTimerReset = 0;
+
+    protected HMT.ArgParser ArgParser = new HMT.ArgParser();
 
     public bool[] characterDied;
 
@@ -94,6 +97,26 @@ public class GameManager : MonoBehaviour
 
         Debug.LogFormat("NetworkMiddleware.S.myCharacterID = {0}", NetworkMiddleware.Instance.myCharacterID);
 
+        ArgParser.AddArg("levelSpec", HMT.ArgParser.ArgType.One);
+        ArgParser.ParseArgs();
+
+        if (ArgParser.CheckFlag("levelSpec")) {
+            try {
+                StreamReader sr = new StreamReader(ArgParser.GetArgValue("levelSpec"));
+                string levelSpec = sr.ReadToEnd();
+                sr.Close();
+                MapGenerator.Instance.ParseLevelSpec(levelSpec);
+            }
+            catch(Exception e) {
+                Debug.LogError("Problem parsing spec file " + e + " Reverting to in-build levels.");
+                MapGenerator.Instance.levelSpecs = null;
+            }
+        }
+
+        if(MapGenerator.Instance.levelSpecs == null) {
+            MapGenerator.Instance.ParseLevelSpec(gameData.levelTextFiles);
+        }
+
 #if HMT_BUILD
         if (isNetworkGame) {
             if (CompetitionMiddleware.Instance.overrideAIMode) {
@@ -128,7 +151,7 @@ public class GameManager : MonoBehaviour
 
     public virtual IEnumerator StartLevel() {
         InSceneShrines = new List<Shrine> { null, null, null }; 
-        MapGenerator.Instance.LoadLevel(gameData.levelTextFiles[currentLevel - 1]);
+        MapGenerator.Instance.LoadLevel(currentLevel - 1);
 
         gameStatus = GameStatus.LevelStart;
         CurrentRound = 0;

--- a/Assets/Scripts/Managers/GameManager.cs
+++ b/Assets/Scripts/Managers/GameManager.cs
@@ -950,7 +950,7 @@ public class GameManager : MonoBehaviour
         Debug.Log("Moving to next currLevel.");
         currentLevel += 1;
 
-        if (currentLevel <= gameData.levelTextFiles.Length) {
+        if (currentLevel <= MapGenerator.Instance.levelSpecs.Count) {
 
             eventQueue.Clear();
             //StopAllCoroutines();

--- a/Assets/Scripts/Managers/LocalGameManager.cs
+++ b/Assets/Scripts/Managers/LocalGameManager.cs
@@ -19,14 +19,13 @@ public class LocalGameManager : GameManager
     protected override void Start() {
         base.Start();
         UIManager.Instance.ShowCharacterSwitcher();
-        HMT.ArgParser argParser = new HMT.ArgParser();
 
-        argParser.AddArg("stepTime", HMT.ArgParser.ArgType.One);
-        argParser.AddArg("instanceMode", HMT.ArgParser.ArgType.Flag);
-        argParser.ParseArgs();
+        ArgParser.AddArg("stepTime", HMT.ArgParser.ArgType.One);
+        ArgParser.AddArg("instanceMode", HMT.ArgParser.ArgType.Flag);
+        ArgParser.ParseArgs();
 
-        excecutionStepTime = argParser.GetArgValue("stepTime", excecutionStepTime);
-        if (argParser.CheckFlag("instantMode")) {
+        excecutionStepTime = ArgParser.GetArgValue("stepTime", excecutionStepTime);
+        if (ArgParser.CheckFlag("instantMode")) {
             excecutionStepTime = 0;
         }
     }


### PR DESCRIPTION
This re-works the system for text specification of levels in a few ways:

- Multiple levels can now appear in a single file (delimited by `` ` ``)
- A new MacroDefaultLevelSpec exists that is the sole specification for the default levels (all the original text asset files are also still there)
- A new level spec can be provided at runtime using a `-levelSpec` command line arg. If there is a failure to parse the provided file it will fall back on the in-built level spec.